### PR TITLE
feat: storage.ts のメソッドを非同期化する

### DIFF
--- a/learn/summary.md
+++ b/learn/summary.md
@@ -65,6 +65,77 @@ randomUUID()
 
 ---
 
+## 非同期処理（async / await）
+
+### なぜ非同期処理が必要か
+
+ファイルI/OやAPIリクエストなどは処理に時間がかかる。同期処理だとその間プログラム全体が止まるが、非同期処理なら待っている間に他の処理を進められる。
+
+### async 関数
+
+`async` を付けた関数は**必ず `Promise` を返す**。
+
+```ts
+// 同期
+const readLogs = (): LogEntry[] => { ... }
+
+// 非同期
+const readLogs = async (): Promise<LogEntry[]> => { ... }
+```
+
+### await
+
+`Promise` の解決を待つ。**`async` 関数の中でのみ使用できる**。
+
+```ts
+const addLog = async (message: string): Promise<void> => {
+  const logs = await readLogs();   // Promise が解決するまで待つ
+  await writeLogs([...logs, entry]);
+};
+```
+
+### Promise\<T\>
+
+非同期処理の結果の型。`T` は解決後の値の型。
+
+| 型 | 意味 |
+|---|---|
+| `Promise<LogEntry[]>` | 解決すると `LogEntry[]` が得られる |
+| `Promise<void>` | 解決しても値はない（戻り値なし） |
+
+### fs/promises
+
+Node.js のファイルAPIには同期版と非同期版がある。
+
+```ts
+// 同期版（処理が終わるまでブロックする）
+import fs from 'fs';
+fs.readFileSync(FILE, 'utf-8');
+
+// 非同期版（Promise を返す）
+import fs from 'fs/promises';
+await fs.readFile(FILE, 'utf-8');
+```
+
+### try/catch でエラーをハンドリング
+
+非同期処理のエラーは `try/catch` でキャッチする。
+
+```ts
+const readLogs = async (): Promise<LogEntry[]> => {
+  try {
+    const raw = await fs.readFile(FILE, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return []; // ファイルが存在しない場合など
+  }
+};
+```
+
+`existsSync` で存在確認 → `readFileSync` で読み込む、という2ステップを1つの `try/catch` にまとめられる。
+
+---
+
 ## TypeScript 独自の構文
 
 ### 型エイリアス

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -2,13 +2,13 @@ import { readLogs, writeLogs } from '../storage';
 import { LogEntry } from '../types';
 import { randomUUID } from 'crypto';
 
-export const addLog = (message: string): void => {
-  const logs = readLogs();
+export const addLog = async (message: string): Promise<void> => {
+  const logs = await readLogs();
   const entry: LogEntry = {
     id: randomUUID(),
     message,
     createdAt: new Date().toISOString(),
   };
-  writeLogs([...logs, entry]);
+  await writeLogs([...logs, entry]);
   console.log(`追加しました: ${message}`);
 };

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import { readLogs } from '../storage';
 
-export const listLogs = (today: boolean): void => {
-  let logs = readLogs();
+export const listLogs = async (today: boolean): Promise<void> => {
+  let logs = await readLogs();
   if (today) {
     const todayStr = new Date().toISOString().slice(0, 10);
     logs = logs.filter((l) => l.createdAt.startsWith(todayStr));

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,7 +1,7 @@
 import { readLogs } from '../storage';
 
-export const statsLogs = (week: boolean): void => {
-  let logs = readLogs();
+export const statsLogs = async (week: boolean): Promise<void> => {
+  let logs = await readLogs();
   if (week) {
     const weekAgo = new Date();
     weekAgo.setDate(weekAgo.getDate() - 7);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,14 +1,17 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { LogEntry } from './types';
 
 const FILE = 'data/logs.json';
 
-export const readLogs = (): LogEntry[] => {
-  if (!fs.existsSync(FILE)) return [];
-  const raw = fs.readFileSync(FILE, 'utf-8');
-  return JSON.parse(raw);
+export const readLogs = async (): Promise<LogEntry[]> => {
+  try {
+    const raw = await fs.readFile(FILE, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
 };
 
-export const writeLogs = (logs: LogEntry[]): void => {
-  fs.writeFileSync(FILE, JSON.stringify(logs, null, 2));
+export const writeLogs = async (logs: LogEntry[]): Promise<void> => {
+  await fs.writeFile(FILE, JSON.stringify(logs, null, 2));
 };


### PR DESCRIPTION
## 概要

Close #1

`storage.ts` の同期的なファイルI/Oを非同期化し、TypeScript の `async/await` を実践的に学習した。

## 変更内容

### storage.ts
- `fs` → `fs/promises` に変更
- `readLogs` / `writeLogs` を `async` 関数に変更（戻り値を `Promise<T>` に）
- `existsSync` + `readFileSync` の組み合わせを `readFile` の `try/catch` に置き換え

### commands/
- `addLog` / `listLogs` / `statsLogs` を `async` 関数に変更
- `readLogs` / `writeLogs` の呼び出しに `await` を追加

### learn/summary.md
- 非同期処理（`async/await`）のまとめセクションを追記

## コミット構成

| コミット | 内容 |
|---|---|
| `refactor(storage)` | storage.ts の非同期化 |
| `refactor(commands)` | 呼び出し側への await 追加 |
| `docs(learn)` | 学習まとめの追記 |

## 動作確認

```bash
npx tsc --noEmit  # 型エラーなし
```